### PR TITLE
Refine FloatLiteral implementation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Changelog
 
 X.Y.Z (DD-MM-YYYY)
 ------------------
+* Refine FloatLiteral implementation (:pr:`17`)
 * Move kernel functionality into ESKernel class (:pr:`16`)
 * Move gridder argument checks into a separate function (:pr:`15`)
 * Align ducc0 and numba wgridder parameters (:pr:`14`)

--- a/radiomesh/literals.py
+++ b/radiomesh/literals.py
@@ -1,0 +1,32 @@
+import warnings
+
+from numba.core import types
+
+FloatLiteral: type[types.Literal] | None = None
+
+
+def install_float_literal() -> type[types.Literal]:
+  try:
+    # numba doesn't yet seem to have a FloatLiteral
+    # but future-proof this just in case
+    FloatLiteral = types.Literal.ctor_map[float]
+    warnings.warn("Using numba FloatLiteral instead of radiomesh's custom FloatLiteral")
+  except KeyError:
+    # Create a basic FloatLiteral type that is sufficient to be recognised by @overload
+    # Values of this type are probably unusable in jitted function implementations.
+    from numba.core.boxing import NativeValue, unbox
+    from numba.core.datamodel.models import OpaqueModel, register_default
+
+    class RadioMeshFloatLiteral(types.Literal, types.Dummy):
+      pass
+
+    @unbox(RadioMeshFloatLiteral)
+    def unbox_float_literal(typ, obj, c):
+      return NativeValue(c.context.get_dummy_value())
+
+    # Register model and literal
+    register_default(RadioMeshFloatLiteral)(OpaqueModel)
+    types.Literal.ctor_map[float] = RadioMeshFloatLiteral
+    FloatLiteral = RadioMeshFloatLiteral
+
+  return FloatLiteral


### PR DESCRIPTION
This reworked implementation is sufficient for FloatLiteral's to be identified by `numba.extending.overload`. Unfortunately it's not usable in conjunction with other numba code as numba tries to use it with internal float types.

However, this demonstrates a way to create literal types recognised by numba and could be extended to compound structures.

<!--
Consider opening an enhancement issue
if the change is large or complex.
https://github.com/ratt-ru/radiomesh/issues/new/choose
-->

Thanks for contributing to radiomesh.

Please add:

- [x] Test Cases covering your PR.
- [ ] Documentation.
- [x] A Changelog entry in `CHANGELOG.rst`.
