### PR TITLE
Expand Datum literal handling.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,8 @@ Changelog
 
 X.Y.Z (DD-MM-YYYY)
 ------------------
+* Datums containing integers, booleans and strings are converted to numba {Integer,Boolean,String}Literal types (:pr:`62`)
+* Create a specific FloatDatumLiteral for embedding literal floats in jitted code (:pr:`62`)
 * Simplify ``DatumLiteral`` (:pr:`61`)
 * Add ``is_datum_literal`` helper method (:pr:`60`)
 * Expose DatumLiteral's value in jitted code (:pr:`60`)

--- a/radiomesh/literals.py
+++ b/radiomesh/literals.py
@@ -4,7 +4,7 @@ from typing import Any, Callable, Generic, Hashable, Tuple, TypeVar
 
 from numba.core import types
 from numba.core.datamodel.models import OpaqueModel, register_default
-from numba.core.errors import TypingError
+from numba.core.imputils import lower_cast
 from numba.extending import NativeValue, overload_attribute, typeof_impl, unbox
 
 
@@ -91,9 +91,15 @@ class DatumLiteral(Generic[H], types.Literal, types.Dummy):
     super(types.Dummy, self).__init__(name=name)
     self._literal_init(value)
 
-  @staticmethod
-  def from_datum(datum: Datum[H]):
-    return DatumLiteral(datum.value)
+
+class FloatDatumLiteral(DatumLiteral):
+  pass
+
+
+@lower_cast(FloatDatumLiteral, types.Float)
+def literal_float_to_number(context, builder, fromty, toty, val):
+  lit = context.get_constant_generic(builder, fromty.literal_type, fromty.literal_value)
+  return context.cast(builder, lit, fromty.literal_type, toty)
 
 
 def is_datum_literal(obj, typ):
@@ -102,16 +108,32 @@ def is_datum_literal(obj, typ):
 
 
 @unbox(DatumLiteral)
+@unbox(FloatDatumLiteral)
 def unbox_datum_literal(typ, obj, c):
   """Convert a Python DatumLiteral to a Numba representation
   Here we can just the Python DatumLiteral itself"""
   return NativeValue(c.context.get_dummy_value())
 
 
+def _from_datum(datum: Datum):
+  """Converts from a Datum to the appropriate numba Literal type
+  or to a DatumLiteral"""
+  if isinstance(value := datum.value, float):
+    return FloatDatumLiteral(value)
+  elif isinstance(value, bool):
+    return types.BooleanLiteral(value)
+  elif isinstance(value, int):
+    return types.IntegerLiteral(value)
+  elif isinstance(value, str):
+    return types.StringLiteral(value)
+
+  return DatumLiteral(value)
+
+
 @typeof_impl.register(Datum)
 def typeof_datum(val, c):
   """This is sufficient to use Datum within a numba.njit function"""
-  return DatumLiteral(val.value)
+  return _from_datum(val)
 
 
 # DatumLiteral is only implemented as a simple Literal and Dummy type
@@ -119,16 +141,16 @@ def typeof_datum(val, c):
 # It's functionality is minimally exposed within the numba layer so we
 # only register it with an OpaqueModel.
 register_default(DatumLiteral)(OpaqueModel)
+register_default(FloatDatumLiteral)(OpaqueModel)
 
 # This ensures numba.literally(Datum(...)) produces a DatumLiteral
-types.Literal.ctor_map[Datum] = DatumLiteral.from_datum
+types.Literal.ctor_map[Datum] = _from_datum
 
 
 @overload_attribute(DatumLiteral, "literal_value")
+@overload_attribute(FloatDatumLiteral, "literal_value")
 def overload_datum_value(self):
-  if not isinstance(self, DatumLiteral):
-    raise TypingError(f"{self} is not a DatumLiteral")
-
   """Returns the literal_value of a DatumLiteral"""
-  VALUE = self.literal_value
-  return lambda self: VALUE
+  if isinstance(self, DatumLiteral):
+    VALUE = self.literal_value
+    return lambda self: VALUE

--- a/radiomesh/tests/test_literals.py
+++ b/radiomesh/tests/test_literals.py
@@ -59,7 +59,7 @@ def f_overload(x, datum):
 
 @numba.njit(cache=True)
 def f(x, value):
-  return f_impl(x, numba.literally(value))
+  return f_impl(x, value)
 
 
 def test_datum_literal():
@@ -106,3 +106,25 @@ def test_datum_caching(tmp_path):
   assert f"data saved to '{tmp_path}" in combined
   assert f"data loaded from '{tmp_path}" in combined
   assert f"index loaded from '{tmp_path}" in combined
+
+
+def test_datum_literal_casts():
+  """Tests that Datums wrapping types for which numba Literals
+  exist are converted into a {String,Integer,Boolean}Literal."""
+  str_datum = Datum("Hello")
+  assert numba.njit(lambda: str_datum + " World")() == "Hello World"
+
+  int_datum = Datum(1)
+  assert numba.njit(lambda: int_datum + 2)() == 3
+
+  # Without the bool(...) the raw bool value is dumped
+  # straight into the IR
+  bool_datum = Datum(False)
+  assert numba.njit(lambda: bool(bool_datum) or True)() is True
+
+
+def test_datum_literal_float_cast():
+  """Test that a Datum containing a float is converted to a
+  FloatDatumLiteral and then cast to a float"""
+  float_datum = Datum(4.0)
+  assert numba.njit(lambda a: a + float_datum)(2.0) == 6.0


### PR DESCRIPTION
1. Datums containing integers, booleans and strings are converted to numba {Integer,Boolean,String}Literal types.
2. Create a specific FloatDatumLiteral for embedding literal floats in jitted code.

<!--
Consider opening an enhancement issue
if the change is large or complex.
https://github.com/ratt-ru/radiomesh/issues/new/choose
-->

Thanks for contributing to radiomesh.

Please add:

- [x] Test Cases covering your PR.
- [ ] Documentation.
- [x] A Changelog entry in `CHANGELOG.rst`.
