### PR TITLE
Move sympy to an optional scripts dependency

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Changelog
 
 X.Y.Z (DD-MM-YYYY)
 ------------------
+* Move ``sympy`` into ``scripts`` and ``test`` dependency groups (:pr:`65`)
 * Provide distinct {Boolean,Float,Integer,String}DatumLiteral types (:pr:`63`)
 * Datums containing integers, booleans and strings are converted to numba {Integer,Boolean,String}Literal types (:pr:`62`)
 * Create a specific FloatDatumLiteral for embedding literal floats in jitted code (:pr:`62`)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ requires-python = ">=3.10, <3.14"
 dependencies = [
     "numpy>=2.0.0",
     "numba>=0.60.0",
-    "sympy>=1.9",
 ]
 
 [dependency-groups]
@@ -32,6 +31,11 @@ dev = [
 [project.scripts]
 
 radiomesh = "radiomesh.scripts.main:main"
+
+[project.optional-dependencies]
+scripts = [
+    "sympy>=1.14.0",
+]
 
 [build-system]
 requires = ["hatchling"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ test = [
     "xarray-ms",
     "requests",
     "ducc0",
+    "sympy>=1.14.0",
 ]
 dev = [
     "pre-commit>=4.2.0",


### PR DESCRIPTION
sympy is only strictly needed for generating stokes expressions.

<!--
Consider opening an enhancement issue
if the change is large or complex.
https://github.com/ratt-ru/radiomesh/issues/new/choose
-->

Thanks for contributing to radiomesh.

<!--  dummy -->

Please add:

- [ ] Test Cases covering your PR.
- [ ] Documentation.
- [x] A Changelog entry in `CHANGELOG.rst`.
