### PR TITLE
Generate diag-jones and minvar stokes expression variants

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Changelog
 
 X.Y.Z (DD-MM-YYYY)
 ------------------
+* Add DIAG and MINVAR versions of the generated Stokes expressions (:pr:`81`)
 * Extract general-purpose numba intrinsics, literals, and concurrency primitives
   into ``rarg-numba-patterns`` (:pr:`80`)
 * Replace ESKernel dataclass with a StructRef ESKernel (:pr:`78`)

--- a/radiomesh/_intrinsics_extra.py
+++ b/radiomesh/_intrinsics_extra.py
@@ -20,8 +20,7 @@ def apply_weights(
 
   if not is_float_weight and not is_tuple_weight:
     raise TypingError(
-      f"'weight' ({weight}) must be a float or "
-      f"a tuple of values of length {len(data)}"
+      f"'weight' ({weight}) must be a float or a tuple of values of length {len(data)}"
     )
 
   unified_type = typingctx.unify_types(
@@ -109,8 +108,7 @@ def check_args(uvw, visibilities, weights, flags, frequencies, nschema_pol):
 
   if frequencies.shape[0] != visibilities.shape[-2]:
     raise ValueError(
-      "Frequency shape does not match the visibility shape "
-      "in the frequency dimension"
+      "Frequency shape does not match the visibility shape in the frequency dimension"
     )
 
   if not (visibilities.shape == weights.shape == flags.shape):

--- a/radiomesh/generated/_stokes_expr.py
+++ b/radiomesh/generated/_stokes_expr.py
@@ -178,6 +178,54 @@ def LINEAR_WEIGHT_NOJONES_V(w00, w01, w10, w11):
   return (w01 + w10).real
 
 
+def LINEAR_VIS_DIAGJONES_I(v00, v01, v10, v11, jp00, jp11, jq00, jq11):
+  return 0.5 * v11 / (jp11 * conj(jq11)) + 0.5 * v00 / (jp00 * conj(jq00))
+
+
+def LINEAR_VIS_DIAGJONES_Q(v00, v01, v10, v11, jp00, jp11, jq00, jq11):
+  return -0.5 * v11 / (jp11 * conj(jq11)) + 0.5 * v00 / (jp00 * conj(jq00))
+
+
+def LINEAR_VIS_DIAGJONES_U(v00, v01, v10, v11, jp00, jp11, jq00, jq11):
+  return 0.5 * v10 / (jp11 * conj(jq00)) + 0.5 * v01 / (jp00 * conj(jq11))
+
+
+def LINEAR_VIS_DIAGJONES_V(v00, v01, v10, v11, jp00, jp11, jq00, jq11):
+  return 0.5 * 1j * v10 / (jp11 * conj(jq00)) - 0.5 * 1j * v01 / (jp00 * conj(jq11))
+
+
+def LINEAR_WEIGHT_DIAGJONES_I(w00, w01, w10, w11, jp00, jp11, jq00, jq11):
+  return (jp00 * jq00 * w00 * conj(jp00) * conj(jq00) + jp11 * jq11 * w11 * conj(jp11) * conj(jq11)).real
+
+
+def LINEAR_WEIGHT_DIAGJONES_Q(w00, w01, w10, w11, jp00, jp11, jq00, jq11):
+  return (jp00 * jq00 * w00 * conj(jp00) * conj(jq00) + jp11 * jq11 * w11 * conj(jp11) * conj(jq11)).real
+
+
+def LINEAR_WEIGHT_DIAGJONES_U(w00, w01, w10, w11, jp00, jp11, jq00, jq11):
+  return (jp00 * jq11 * w01 * conj(jp00) * conj(jq11) + jp11 * jq00 * w10 * conj(jp11) * conj(jq00)).real
+
+
+def LINEAR_WEIGHT_DIAGJONES_V(w00, w01, w10, w11, jp00, jp11, jq00, jq11):
+  return (jp00 * jq11 * w01 * conj(jp00) * conj(jq11) + jp11 * jq00 * w10 * conj(jp11) * conj(jq00)).real
+
+
+def LINEAR_WEIGHT_MINVAR_DIAGJONES_I(w00, w01, w10, w11, jp00, jp11, jq00, jq11):
+  return 4 * min((jp00 * jq00 * w00 * conj(jp00) * conj(jq00)).real, (jp11 * jq11 * w11 * conj(jp11) * conj(jq11)).real)
+
+
+def LINEAR_WEIGHT_MINVAR_DIAGJONES_Q(w00, w01, w10, w11, jp00, jp11, jq00, jq11):
+  return 4 * min((jp00 * jq00 * w00 * conj(jp00) * conj(jq00)).real, (jp11 * jq11 * w11 * conj(jp11) * conj(jq11)).real)
+
+
+def LINEAR_WEIGHT_MINVAR_DIAGJONES_U(w00, w01, w10, w11, jp00, jp11, jq00, jq11):
+  return 4 * min((jp00 * jq11 * w01 * conj(jp00) * conj(jq11)).real, (jp11 * jq00 * w10 * conj(jp11) * conj(jq00)).real)
+
+
+def LINEAR_WEIGHT_MINVAR_DIAGJONES_V(w00, w01, w10, w11, jp00, jp11, jq00, jq11):
+  return 4 * min((jp00 * jq11 * w01 * conj(jp00) * conj(jq11)).real, (jp11 * jq00 * w10 * conj(jp11) * conj(jq00)).real)
+
+
 def CIRCULAR_VIS_JONES_I(v00, v01, v10, v11, jp00, jp01, jp10, jp11, jq00, jq01, jq10, jq11):
   return (
     0.5
@@ -351,6 +399,54 @@ def CIRCULAR_WEIGHT_NOJONES_V(w00, w01, w10, w11):
   return (w00 + w11).real
 
 
+def CIRCULAR_VIS_DIAGJONES_I(v00, v01, v10, v11, jp00, jp11, jq00, jq11):
+  return 0.5 * v11 / (jp11 * conj(jq11)) + 0.5 * v00 / (jp00 * conj(jq00))
+
+
+def CIRCULAR_VIS_DIAGJONES_Q(v00, v01, v10, v11, jp00, jp11, jq00, jq11):
+  return 0.5 * v10 / (jp11 * conj(jq00)) + 0.5 * v01 / (jp00 * conj(jq11))
+
+
+def CIRCULAR_VIS_DIAGJONES_U(v00, v01, v10, v11, jp00, jp11, jq00, jq11):
+  return 0.5 * 1j * v10 / (jp11 * conj(jq00)) - 0.5 * 1j * v01 / (jp00 * conj(jq11))
+
+
+def CIRCULAR_VIS_DIAGJONES_V(v00, v01, v10, v11, jp00, jp11, jq00, jq11):
+  return -0.5 * v11 / (jp11 * conj(jq11)) + 0.5 * v00 / (jp00 * conj(jq00))
+
+
+def CIRCULAR_WEIGHT_DIAGJONES_I(w00, w01, w10, w11, jp00, jp11, jq00, jq11):
+  return (jp00 * jq00 * w00 * conj(jp00) * conj(jq00) + jp11 * jq11 * w11 * conj(jp11) * conj(jq11)).real
+
+
+def CIRCULAR_WEIGHT_DIAGJONES_Q(w00, w01, w10, w11, jp00, jp11, jq00, jq11):
+  return (jp00 * jq11 * w01 * conj(jp00) * conj(jq11) + jp11 * jq00 * w10 * conj(jp11) * conj(jq00)).real
+
+
+def CIRCULAR_WEIGHT_DIAGJONES_U(w00, w01, w10, w11, jp00, jp11, jq00, jq11):
+  return (jp00 * jq11 * w01 * conj(jp00) * conj(jq11) + jp11 * jq00 * w10 * conj(jp11) * conj(jq00)).real
+
+
+def CIRCULAR_WEIGHT_DIAGJONES_V(w00, w01, w10, w11, jp00, jp11, jq00, jq11):
+  return (jp00 * jq00 * w00 * conj(jp00) * conj(jq00) + jp11 * jq11 * w11 * conj(jp11) * conj(jq11)).real
+
+
+def CIRCULAR_WEIGHT_MINVAR_DIAGJONES_I(w00, w01, w10, w11, jp00, jp11, jq00, jq11):
+  return 4 * min((jp00 * jq00 * w00 * conj(jp00) * conj(jq00)).real, (jp11 * jq11 * w11 * conj(jp11) * conj(jq11)).real)
+
+
+def CIRCULAR_WEIGHT_MINVAR_DIAGJONES_Q(w00, w01, w10, w11, jp00, jp11, jq00, jq11):
+  return 4 * min((jp00 * jq11 * w01 * conj(jp00) * conj(jq11)).real, (jp11 * jq00 * w10 * conj(jp11) * conj(jq00)).real)
+
+
+def CIRCULAR_WEIGHT_MINVAR_DIAGJONES_U(w00, w01, w10, w11, jp00, jp11, jq00, jq11):
+  return 4 * min((jp00 * jq11 * w01 * conj(jp00) * conj(jq11)).real, (jp11 * jq00 * w10 * conj(jp11) * conj(jq00)).real)
+
+
+def CIRCULAR_WEIGHT_MINVAR_DIAGJONES_V(w00, w01, w10, w11, jp00, jp11, jq00, jq11):
+  return 4 * min((jp00 * jq00 * w00 * conj(jp00) * conj(jq00)).real, (jp11 * jq11 * w11 * conj(jp11) * conj(jq11)).real)
+
+
 CONVERT_FNS = {
   ("VIS", "LINEAR", "JONES", "I"): LINEAR_VIS_JONES_I,
   ("VIS", "LINEAR", "JONES", "Q"): LINEAR_VIS_JONES_Q,
@@ -368,6 +464,18 @@ CONVERT_FNS = {
   ("WEIGHT", "LINEAR", "NOJONES", "Q"): LINEAR_WEIGHT_NOJONES_Q,
   ("WEIGHT", "LINEAR", "NOJONES", "U"): LINEAR_WEIGHT_NOJONES_U,
   ("WEIGHT", "LINEAR", "NOJONES", "V"): LINEAR_WEIGHT_NOJONES_V,
+  ("VIS", "LINEAR", "DIAGJONES", "I"): LINEAR_VIS_DIAGJONES_I,
+  ("VIS", "LINEAR", "DIAGJONES", "Q"): LINEAR_VIS_DIAGJONES_Q,
+  ("VIS", "LINEAR", "DIAGJONES", "U"): LINEAR_VIS_DIAGJONES_U,
+  ("VIS", "LINEAR", "DIAGJONES", "V"): LINEAR_VIS_DIAGJONES_V,
+  ("WEIGHT", "LINEAR", "DIAGJONES", "I"): LINEAR_WEIGHT_DIAGJONES_I,
+  ("WEIGHT", "LINEAR", "DIAGJONES", "Q"): LINEAR_WEIGHT_DIAGJONES_Q,
+  ("WEIGHT", "LINEAR", "DIAGJONES", "U"): LINEAR_WEIGHT_DIAGJONES_U,
+  ("WEIGHT", "LINEAR", "DIAGJONES", "V"): LINEAR_WEIGHT_DIAGJONES_V,
+  ("WEIGHT_MINVAR", "LINEAR", "DIAGJONES", "I"): LINEAR_WEIGHT_MINVAR_DIAGJONES_I,
+  ("WEIGHT_MINVAR", "LINEAR", "DIAGJONES", "Q"): LINEAR_WEIGHT_MINVAR_DIAGJONES_Q,
+  ("WEIGHT_MINVAR", "LINEAR", "DIAGJONES", "U"): LINEAR_WEIGHT_MINVAR_DIAGJONES_U,
+  ("WEIGHT_MINVAR", "LINEAR", "DIAGJONES", "V"): LINEAR_WEIGHT_MINVAR_DIAGJONES_V,
   ("VIS", "CIRCULAR", "JONES", "I"): CIRCULAR_VIS_JONES_I,
   ("VIS", "CIRCULAR", "JONES", "Q"): CIRCULAR_VIS_JONES_Q,
   ("VIS", "CIRCULAR", "JONES", "U"): CIRCULAR_VIS_JONES_U,
@@ -384,4 +492,16 @@ CONVERT_FNS = {
   ("WEIGHT", "CIRCULAR", "NOJONES", "Q"): CIRCULAR_WEIGHT_NOJONES_Q,
   ("WEIGHT", "CIRCULAR", "NOJONES", "U"): CIRCULAR_WEIGHT_NOJONES_U,
   ("WEIGHT", "CIRCULAR", "NOJONES", "V"): CIRCULAR_WEIGHT_NOJONES_V,
+  ("VIS", "CIRCULAR", "DIAGJONES", "I"): CIRCULAR_VIS_DIAGJONES_I,
+  ("VIS", "CIRCULAR", "DIAGJONES", "Q"): CIRCULAR_VIS_DIAGJONES_Q,
+  ("VIS", "CIRCULAR", "DIAGJONES", "U"): CIRCULAR_VIS_DIAGJONES_U,
+  ("VIS", "CIRCULAR", "DIAGJONES", "V"): CIRCULAR_VIS_DIAGJONES_V,
+  ("WEIGHT", "CIRCULAR", "DIAGJONES", "I"): CIRCULAR_WEIGHT_DIAGJONES_I,
+  ("WEIGHT", "CIRCULAR", "DIAGJONES", "Q"): CIRCULAR_WEIGHT_DIAGJONES_Q,
+  ("WEIGHT", "CIRCULAR", "DIAGJONES", "U"): CIRCULAR_WEIGHT_DIAGJONES_U,
+  ("WEIGHT", "CIRCULAR", "DIAGJONES", "V"): CIRCULAR_WEIGHT_DIAGJONES_V,
+  ("WEIGHT_MINVAR", "CIRCULAR", "DIAGJONES", "I"): CIRCULAR_WEIGHT_MINVAR_DIAGJONES_I,
+  ("WEIGHT_MINVAR", "CIRCULAR", "DIAGJONES", "Q"): CIRCULAR_WEIGHT_MINVAR_DIAGJONES_Q,
+  ("WEIGHT_MINVAR", "CIRCULAR", "DIAGJONES", "U"): CIRCULAR_WEIGHT_MINVAR_DIAGJONES_U,
+  ("WEIGHT_MINVAR", "CIRCULAR", "DIAGJONES", "V"): CIRCULAR_WEIGHT_MINVAR_DIAGJONES_V,
 }

--- a/radiomesh/jones_intrinsics.py
+++ b/radiomesh/jones_intrinsics.py
@@ -78,7 +78,7 @@ def maybe_apply_jones_overload(apply_jones_literal, jones_params, data, idx):
     or not all(isinstance(i, types.Integer) for i in idx)
   ):
     raise TypingError(
-      f"'idx' {idx} must be a " f"(time, baseline, channel, direction) index tuple"
+      f"'idx' {idx} must be a (time, baseline, channel, direction) index tuple"
     )
 
   DATA_TYPE = apply_jones.data_type

--- a/radiomesh/scripts/gen_expr.py
+++ b/radiomesh/scripts/gen_expr.py
@@ -28,6 +28,9 @@ WEIGHT_ARGUMENTS = ["w00", "w01", "w10", "w11"]
 VIS_ARGUMENTS = ["v00", "v01", "v10", "v11"]
 WEIGHT_FN_ARGUMENTS = WEIGHT_ARGUMENTS + JONES_P_ARGUMENTS + JONES_Q_ARGUMENTS
 VIS_FN_ARGUMENTS = VIS_ARGUMENTS + JONES_P_ARGUMENTS + JONES_Q_ARGUMENTS
+DIAG_JONES_ARGUMENTS = ["jp00", "jp11", "jq00", "jq11"]
+DIAG_WEIGHT_FN_ARGUMENTS = WEIGHT_ARGUMENTS + DIAG_JONES_ARGUMENTS
+DIAG_VIS_FN_ARGUMENTS = VIS_ARGUMENTS + DIAG_JONES_ARGUMENTS
 
 
 def sympy_expressions(
@@ -165,6 +168,48 @@ def generate_expression(args: Namespace):
       conv_fns[key] = fn_name
       lines.append(f"def {fn_name}({', '.join(WEIGHT_ARGUMENTS)}):\n")
       lines.append(f"  return ({subs_sympy(wgt_nojones)}).real\n")
+      lines.append("\n")
+
+    # Diagonal-jones variants: substitute off-diagonal jones terms to zero
+    # before simplification. Required by pfb-imaging's weight_data (diag
+    # jones path) and by the minvar weights, which cannot be derived from
+    # the full-jones expressions (Min over expansion terms would select
+    # the structurally-zero cross terms).
+    jp01, jp10 = sympy.symbols("jp01 jp10", real=False)
+    jq01, jq10 = sympy.symbols("jq01 jq10", real=False)
+    diag_subs = {jp01: 0, jp10: 0, jq01: 0, jq10: 0}
+    _, coh_full, wgt_full, _, _ = sympy_expressions(pol_type)
+    coh_diag = sympy.simplify(coh_full.subs(diag_subs))
+    wgt_diag = sympy.simplify(wgt_full.subs(diag_subs))
+
+    for stokes, coh in zip(stokes_schema, coh_diag):
+      fn_name = f"{pol_type.upper()}_VIS_DIAGJONES_{stokes.upper()}"
+      key = ("VIS", pol_type.upper(), "DIAGJONES", stokes.upper())
+      conv_fns[key] = fn_name
+      lines.append(f"def {fn_name}({', '.join(DIAG_VIS_FN_ARGUMENTS)}):\n")
+      lines.append(f"  return {subs_sympy(coh)}\n")
+      lines.append("\n")
+
+    for stokes, wgt in zip(stokes_schema, wgt_diag):
+      fn_name = f"{pol_type.upper()}_WEIGHT_DIAGJONES_{stokes.upper()}"
+      key = ("WEIGHT", pol_type.upper(), "DIAGJONES", stokes.upper())
+      conv_fns[key] = fn_name
+      lines.append(f"def {fn_name}({', '.join(DIAG_WEIGHT_FN_ARGUMENTS)}):\n")
+      lines.append(f"  return ({subs_sympy(wgt)}).real\n")
+      lines.append("\n")
+
+    for stokes, wgt in zip(stokes_schema, wgt_diag):
+      # Minimum-variance weights: 4 * min over the expansion terms of the
+      # diag weight expression, each term cast to real (the terms are
+      # real-valued products; builtin min cannot order complex values).
+      fn_name = f"{pol_type.upper()}_WEIGHT_MINVAR_DIAGJONES_{stokes.upper()}"
+      key = ("WEIGHT_MINVAR", pol_type.upper(), "DIAGJONES", stokes.upper())
+      conv_fns[key] = fn_name
+      expanded = sympy.expand(wgt)
+      terms = expanded.args if isinstance(expanded, sympy.Add) else (expanded,)
+      term_srcs = ", ".join(f"({subs_sympy(t)}).real" for t in terms)
+      lines.append(f"def {fn_name}({', '.join(DIAG_WEIGHT_FN_ARGUMENTS)}):\n")
+      lines.append(f"  return 4 * min({term_srcs})\n")
       lines.append("\n")
 
   lines.append("CONVERT_FNS = {\n")

--- a/radiomesh/stokes_intrinsics.py
+++ b/radiomesh/stokes_intrinsics.py
@@ -91,8 +91,7 @@ def check_stokes_datasources(stokes_schema, data_schema, data_source_map):
       deps = STOKES_DEPENDENCIES[stokes]
     except KeyError:
       raise ValueError(
-        f"{stokes} is not a valid "
-        f"stokes parameter: {list(STOKES_DEPENDENCIES.keys())}"
+        f"{stokes} is not a valid stokes parameter: {list(STOKES_DEPENDENCIES.keys())}"
       )
 
     index_maps = 0

--- a/radiomesh/tests/cmp_vs_ducc.py
+++ b/radiomesh/tests/cmp_vs_ducc.py
@@ -63,7 +63,7 @@ def do_ducc0_wgridding(
 
   print(
     f"Time taken to map ({nrow},{nchan},{ncorr}) to "
-    f"({ncorr},{nx},{ny}) = {time.time()-start}s"
+    f"({ncorr},{nx},{ny}) = {time.time() - start}s"
   )
 
 
@@ -91,7 +91,7 @@ if __name__ == "__main__":
     wgt = ms.getcol("WEIGHT_SPECTRUM")
   except Exception:
     wgt = np.ones(vis.shape, dtype="f4")
-  print(f"Visibility size {vis.nbytes / 1024.**3:.2f}GB")
+  print(f"Visibility size {vis.nbytes / 1024.0**3:.2f}GB")
   ms.close()
   freq = table(f"{args.ms}::SPECTRAL_WINDOW").getcol("CHAN_FREQ")[0]
 
@@ -165,7 +165,7 @@ if __name__ == "__main__":
     )
     print(
       f"Time taken to map ({ntime},{nbl},{nchan},{ncorr}) "
-      f"to ({ncorr},{nx},{ny}) = {time.time()-start}s"
+      f"to ({ncorr},{nx},{ny}) = {time.time() - start}s"
     )
 
   else:

--- a/radiomesh/tests/test_stokes_expr.py
+++ b/radiomesh/tests/test_stokes_expr.py
@@ -1,0 +1,83 @@
+import numpy as np
+import pytest
+import sympy
+
+from radiomesh.generated._stokes_expr import CONVERT_FNS
+from radiomesh.scripts.gen_expr import sympy_expressions
+
+STOKES_SCHEMA = ["I", "Q", "U", "V"]
+
+VIS_DIAG_ARGS = "v00 v01 v10 v11 jp00 jp11 jq00 jq11"
+WEIGHT_DIAG_ARGS = "w00 w01 w10 w11 jp00 jp11 jq00 jq11"
+
+
+def diag_expressions(pol_type):
+  """Diag-jones oracle: the generator's symbolic derivation with
+  off-diagonal jones terms substituted to zero."""
+  schema, C, W, _, _ = sympy_expressions(pol_type)
+  assert schema == STOKES_SCHEMA
+  jp01, jp10, jq01, jq10 = sympy.symbols("jp01 jp10 jq01 jq10", real=False)
+  diag = {jp01: 0, jp10: 0, jq01: 0, jq10: 0}
+  return sympy.simplify(C.subs(diag)), sympy.simplify(W.subs(diag))
+
+
+def random_args(names, rng):
+  values = {}
+  for name in names.split():
+    if name.startswith("w"):
+      values[name] = rng.uniform(0.1, 2.0)
+    else:
+      values[name] = rng.uniform(-1, 1) + rng.uniform(-1, 1) * 1j
+  return values
+
+
+@pytest.mark.parametrize("pol_type", ["linear", "circular"])
+@pytest.mark.parametrize("stokes", STOKES_SCHEMA)
+def test_vis_diagjones(pol_type, stokes):
+  rng = np.random.default_rng(42)
+  C_diag, _ = diag_expressions(pol_type)
+  expr = C_diag[STOKES_SCHEMA.index(stokes)]
+  oracle = sympy.lambdify(
+    sympy.symbols(VIS_DIAG_ARGS), expr, modules=[{"conjugate": np.conjugate}]
+  )
+  fn = CONVERT_FNS[("VIS", pol_type.upper(), "DIAGJONES", stokes)]
+  for _ in range(5):
+    values = random_args(VIS_DIAG_ARGS, rng)
+    np.testing.assert_allclose(fn(**values), oracle(**values), rtol=1e-12)
+
+
+@pytest.mark.parametrize("pol_type", ["linear", "circular"])
+@pytest.mark.parametrize("stokes", STOKES_SCHEMA)
+def test_weight_diagjones(pol_type, stokes):
+  rng = np.random.default_rng(43)
+  _, W_diag = diag_expressions(pol_type)
+  expr = W_diag[STOKES_SCHEMA.index(stokes)]
+  oracle = sympy.lambdify(
+    sympy.symbols(WEIGHT_DIAG_ARGS), expr, modules=[{"conjugate": np.conjugate}]
+  )
+  fn = CONVERT_FNS[("WEIGHT", pol_type.upper(), "DIAGJONES", stokes)]
+  for _ in range(5):
+    values = random_args(WEIGHT_DIAG_ARGS, rng)
+    np.testing.assert_allclose(fn(**values), np.real(oracle(**values)), rtol=1e-12)
+
+
+@pytest.mark.parametrize("pol_type", ["linear", "circular"])
+@pytest.mark.parametrize("stokes", STOKES_SCHEMA)
+def test_weight_minvar_diagjones(pol_type, stokes):
+  """Minvar oracle mirrors pfb-imaging's stokes_funcs construction:
+  4 * Min(*expand(element).args) with Min -> np.minimum."""
+  rng = np.random.default_rng(44)
+  _, W_diag = diag_expressions(pol_type)
+  element = sympy.expand(W_diag[STOKES_SCHEMA.index(stokes)])
+  expr = 4 * sympy.Min(
+    *(element.args if isinstance(element, sympy.Add) else (element,))
+  )
+  oracle = sympy.lambdify(
+    sympy.symbols(WEIGHT_DIAG_ARGS),
+    expr,
+    modules=[{"Min": np.minimum, "conjugate": np.conjugate}],
+  )
+  fn = CONVERT_FNS[("WEIGHT_MINVAR", pol_type.upper(), "DIAGJONES", stokes)]
+  for _ in range(5):
+    values = random_args(WEIGHT_DIAG_ARGS, rng)
+    np.testing.assert_allclose(fn(**values), np.real(oracle(**values)), rtol=1e-12)


### PR DESCRIPTION
This functionality is better placed in `radiomesh`. `pfb-imaging` duplicates too much of it atm. This PR propagates the `daig` and `minvar` modes